### PR TITLE
General fixes to tutorials (applies to 9.0 and 10.0)

### DIFF
--- a/tutorial/gettingstarted/eclipse/PLIDemo.md
+++ b/tutorial/gettingstarted/eclipse/PLIDemo.md
@@ -20,6 +20,23 @@ Please see the Micro Focus product documentation for more information.
 
 ## How to Run the Demonstration
 
+### Connect to the default ESCWA server
+
+Ensure that **Server Explorer** contains a connection to the default Enterprise Server Common Web Administration (ESCWA) server. Note that existing workspaces may already have this connection.
+
+1. In the **Server Explorer** view, right-click and select **New > Enterprise Server Common Web Administration Connection**.
+
+    The **New Enterprise Server Common Web Administration Connection** dialog box is displayed.
+2. In the **Name** field, type **Local**.
+3. In the **Server address** field, type **localhost**.
+4. In the **Server port** field, leave as the default 10086.
+5. If the server connection is TLS-enabled, select **TLS Enabled**, and then click **Browse** and select the appropriate certificate.
+>**Note**: If **TLS Enabled** is selected, but you do not specify a certificate, the default Java keystore is searched for a valid one.
+6. Click **Finish**.
+The new ESCWA connection is displayed at the top level, in the **Server Explorer**.
+
+
+
 ### Import the supplied BANKDEMO enterprise server:
 
 **Note:** If you have already imported the BANKDEMO enterprise server region for the IDE Getting Started tutorial, you scan skip these steps.

--- a/tutorial/gettingstarted/eclipse/PLIDemo.md
+++ b/tutorial/gettingstarted/eclipse/PLIDemo.md
@@ -53,10 +53,10 @@ You must start the HACloud session server before attempting to use the HACloud T
 1. Ensure you have a 64-bit Java installed and added to the PATH environment variable.
 2. Open the Windows Service Manager.
 3. Go to **Micro Focus HA Cloud** and click **Start the service**. 
-4. Alternatively, you can start the session by opening a command prompt and executing the following command:
+4. Alternatively, you can start the session by opening a command prompt as administrator and executing the following command:
 
     ```
-    net start hacloud
+    net start mfhacloud
     ```
 
 **UNIX**

--- a/tutorial/gettingstarted/eclipse/PLIDemo.md
+++ b/tutorial/gettingstarted/eclipse/PLIDemo.md
@@ -35,8 +35,6 @@ Ensure that **Server Explorer** contains a connection to the default Enterprise 
 6. Click **Finish**.
 The new ESCWA connection is displayed at the top level, in the **Server Explorer**.
 
-
-
 ### Import the supplied BANKDEMO enterprise server:
 
 **Note:** If you have already imported the BANKDEMO enterprise server region for the IDE Getting Started tutorial, you scan skip these steps.
@@ -45,6 +43,32 @@ The new ESCWA connection is displayed at the top level, in the **Server Explorer
 2. On the **Server Explorer** tab, right-click **Local** and select **Import Server**.
 4. Click **Browse**, select the `tutorial/BANKDEMO.xml` file, and then click **Finish**.
     The BANKDEMO server should appear in Server Explorer under **Local**.
+
+### Start the HACloud session server
+
+You must start the HACloud session server before attempting to use the HACloud TN3270 terminal emulator. To do this you need to start the respective Windows service (Windows) or the `startsessionserver.sh` script (UNIX).
+
+**Windows**
+
+1. Ensure you have a 64-bit Java installed and added to the PATH environment variable.
+2. Open the Windows Service Manager.
+3. Go to **Micro Focus HA Cloud** and click **Start the service**. 
+4. Alternatively, you can start the session by opening a command prompt and executing the following command:
+
+    ```
+    net start hacloud
+    ```
+
+**UNIX**
+
+1. Ensure that the installed Java is added to the PATH environment variable.
+2. Start the Enterprise Server region that runs the application you want to connect to.
+3. Open a terminal and set up the COBOL environment in it.
+4. Run the following to start the session server:
+
+    ```
+    startsessionserver.sh
+    ```
 
 ### Import the INCLUDES, FETCHABLES, and BANKMAIN projects into an Eclipse workspace:
 

--- a/tutorial/gettingstarted/eclipse/PLIDemo.md
+++ b/tutorial/gettingstarted/eclipse/PLIDemo.md
@@ -13,7 +13,7 @@ You must have the following software installed:
 -   Micro Focus Enterprise Developer for Eclipse. [*Click here*](https://www.microfocus.com/documentation/enterprise-developer/) to access the product Help and the release notes of Enterprise Developer.
 - A TN3270 terminal emulator to run the CICS application.
 
-**Note:** Licenses for Micro Focus Rumba+ Desktop and the HACloud Session Server TN3270 emulator are included with Enterprise Developer. If you do not have Rumba+ Desktop installed, please refer to the Micro Focus Web site.
+**Note:** A license for Micro Focus Host Access for the Cloud (HACloud) Session Server TN3270 emulator is included with Enterprise Developer. 
 
 Before running this demo remotely, be sure you have a Micro Focus RDO and MFDS agent already configured and running on the remote UNIX/Linux machine.
 Please see the Micro Focus product documentation for more information.
@@ -83,12 +83,7 @@ Making these associations before you start the server enables the executables bu
 2. On the Debug Configurations dialog, right-click **PL/I Enterprise Server**, and click **New Configuration**.
 3. Change the **Name** from **New_configuration** to something meaningful like **BANK**.
 4. Type **BANKMAIN** in PL/I project, enter **Local** for **Connection**, enter **BANKDEMO** for **Server**, then click **Apply**, and then click **Debug**.
-5. Open a TN3270 emulation program like Micro Focus Rumba Desktop, and connect to **localhost** (or **127.0.0.1**) on port **9023**.
-   - If using **Micro Focus Rumba+ Desktop**:
-     1. Click **Mainframe Display > Connection > Configure**.
-     2. Click **TN3270** in **Installed Interfaces**.
-     3. On the **TN3270** tab insert **127.0.0.1** and set the **Telnet Port** to **User Defined**, then type **9023**.
-     4. Click **Connect**.
+5. Open a TN3270 emulation program like Micro Focus Host Access for the Cloud, and connect to **localhost** (or **127.0.0.1**) on port **9023**.
 6. If you receive a dialog asking whether to automatically switch to the debug perspective, select **Remember my decision**, and click **Yes**.
 7. Eclipse should automatically open the `SBANK00P.PLI` source file with the SBANK00P PROC line highlighted as the current line of execution.
 8. If line numbers are not turned on in the source window, right-click in the left-hand column of the source pane, and click **Show Line Numbers**.

--- a/tutorial/gettingstarted/eclipse/README.md
+++ b/tutorial/gettingstarted/eclipse/README.md
@@ -3,9 +3,7 @@
 ## Overview
 This set of tutorials guides you through the use of Micro Focus Enterprise Developer for Eclipse. They provide a basic understanding of how the product operates.
 
-These tutorials are designed for developers who have experience with developing COBOL on the mainframe but do not necessarily have a working knowledge of the Eclipse Integrated Development
-
-Environment (IDE). The tutorials provide a basic understanding of the features offered in Enterprise Developer for Eclipse to develop and maintain both simple COBOL and mainframe subsystem applications.
+These tutorials are designed for developers who have experience with developing COBOL on the mainframe but do not necessarily have a working knowledge of the Eclipse Integrated Development Environment (IDE). The tutorials provide a basic understanding of the features offered in Enterprise Developer for Eclipse to develop and maintain both simple COBOL and mainframe subsystem applications.
 
 Other tutorials, which are designed for Administrators, are available.
 

--- a/tutorial/gettingstarted/eclipse/README.md
+++ b/tutorial/gettingstarted/eclipse/README.md
@@ -745,6 +745,14 @@ As with JCL, execution of the jobs requires a previously configured Micro Focus 
 
 **Important:** You need Enterprise Developer or Enterprise Developer for z Systems to execute the application as running applications is not supported in Enterprise Developer Connect.
 
+Before you proceed, ensure that Micro Focus Host Access for the Cloud (HA Cloud) is running:
+
+1. Go the the Start menu and open the Services application.
+
+2. Navigate to the Micro Focus HA Cloud service and check that its status is set to **Running**.
+
+3. If it is not running, right-click and click **Start**.
+
 **Executing the CICS application**
 
 The CICS application requires that you use a 3270 terminal emulator. The installation of Enterprise Developer includes the Micro Focus Rumba+ Desktop emulator. Rumba+ Desktop is available as a standalone application, Rumba+ Desktop, and is also available as a TN3270 Mainframe Display embedded within the IDE. As part of this tutorial, you are going to use the embedded display to run the application.

--- a/tutorial/gettingstarted/eclipse/README.md
+++ b/tutorial/gettingstarted/eclipse/README.md
@@ -740,7 +740,7 @@ As with JCL, execution of the jobs requires a previously configured Micro Focus 
 
 **Important:** You need Enterprise Developer or Enterprise Developer for z Systems to execute the application as running applications is not supported in Enterprise Developer Connect.
 
-Before you proceed, ensure that Micro Focus Host Access for the Cloud (HA Cloud) is running:
+Before you proceed, ensure that Micro Focus Host Access for the Cloud (HACloud) is running:
 
 1. Go the the Start menu and open the Services application.
 

--- a/tutorial/gettingstarted/eclipse/README.md
+++ b/tutorial/gettingstarted/eclipse/README.md
@@ -13,7 +13,7 @@ Other tutorials, which are designed for Administrators, are available.
 * [Creating a Project and Adding the Source Files](#creating-a-project-and-adding-the-source-files)
 * [Editing Source Files](#editing-source-files)
 * [Compiling the Source Code](#unit-testing-the-batch-application)
-* [Unit Testing the Batch Application](#unit-testing-the-online-application)
+* [Unit Testing the Batch Application](#unit-testing-the-batch-application)
 * [Unit Testing the Online Application](#unit-testing-the-online-application)
 * [Debugging the Batch Application](#debugging-the-batch-application)
 * [Debugging the Online Application](#debugging-the-online-application)
@@ -614,6 +614,16 @@ To execute the JCL, you need to run the application in an instance of the Micro 
 
 **Important:** You need Enterprise Developer or Enterprise Developer for z Systems to execute the application as running applications is not supported in Enterprise Developer Connect.
 
+Before you proceed, ensure that the default settings are applied to the Directory Sever:
+
+1.  Click the **Start** menu and open the **Services** application. Navigate to Micro Focus Directory Server to view its status and set it to **Running** if it is not already started.
+
+2.  In Eclipse, click the Server Explorer view.
+
+   If the window is not visible, click **Window** \> **Show View** \> **Other**, then expand **Micro Focus**, click **Server Explorer**, and click **Open**.
+
+3.  Click **Default [127.0.0.1:86]** and in the Properties pane, check the value of the directory server field. If it does not say Default, right-click the value and select **Restore Default Value**.
+
 **Importing the Bankdemo server**
 
 This sample provides a PowerShell script that creates the region definition to use in this tutorial:
@@ -626,9 +636,6 @@ This sample provides a PowerShell script that creates the region definition to u
 Now you can import the definition of the BANKDEMO logical server (LSER) in Enterprise Server:
 
 1.  In Eclipse, click the Server Explorer view.
-
-    If the window is not visible, click **View** \> **Show View** \> **Other**, then expand **Micro Focus**, click **Server Explorer**, and click **Open**.
-
 2.  Right-click **Default [127.0.0.1:86]**, and click **Import Server**.
 3.  In the **Import Server** dialog box, click **Browse** for **Import file**.
 4.  Set the file extension field to **.xml**.

--- a/tutorial/gettingstarted/eclipse/README.md
+++ b/tutorial/gettingstarted/eclipse/README.md
@@ -292,7 +292,7 @@ Notice that some data items in the Data Division are crossed out. This is becaus
 
 **Viewing data definitions**
 
-1. Hover over a data item in the Procedure Division to see information about the data item and how ma times it is used in the program. 
+1. Hover over a data item in the Procedure Division to see information about the data item and how many times it is used in the program. 
 2. Double-click a data item or paragraph name to see the IDE highlights all their occurrences in the code.
 
 **Breadcrumbs**              
@@ -306,9 +306,6 @@ The ![](images/65bc336b21e1ecd824bc6e2a37508068.jpg) (**Toggle Context Breadcrum
 **Marking text and block mode**
 
 You can either use the mouse to mark a block of text or click ![](images/2a6ec092a713afe86e854b35e22548db.jpg) (**Toggle Block Selection Mode**) and select square blocks of text. When a selection is made, you can cut or copy it. 
-
-This turns the data items and the paragraph names you hover over into hyperlinks.
-
 
 **Rename** 
 

--- a/tutorial/gettingstarted/visualstudio/PLIDemo.md
+++ b/tutorial/gettingstarted/visualstudio/PLIDemo.md
@@ -31,6 +31,19 @@ If you have already imported the BANKDEMO enterprise server as part of the "[Get
     
    The BANKDEMO server should appear in Server Explorer under **Local**.
 
+### Start the HACloud session server
+
+You must start the HACloud session server before attempting to use the HACloud TN3270 terminal emulator. To do this you need to start the respective Windows service.
+
+1. Ensure you have a 64-bit Java installed and added to the PATH environment variable.
+2. Open the Windows Service Manager.
+3. Go to **Micro Focus HA Cloud** and click **Start the service**. 
+4. Alternatively, you can start the session by opening a command prompt and executing the following command:
+
+    ```
+    net start hacloud
+    ```
+
 
 ### Configure the BANKDEMO enterprise server for PL/I:
     

--- a/tutorial/gettingstarted/visualstudio/PLIDemo.md
+++ b/tutorial/gettingstarted/visualstudio/PLIDemo.md
@@ -15,7 +15,7 @@ This demonstration requires:
 - A TN3270 terminal emulator to run the CICS application. 
 
 **Note:**
-Licenses for Micro Focus Rumba+ Desktop and the HACloud Session Server TN3270 emulator are included with Enterprise Developer. If you do not have Rumba+ Desktop installed, please refer to the Micro Focus Web site.
+A license for Micro Focus Host Access for the Cloud (HACloud) TN3270 emulator is included with Enterprise Developer. 
 
 ## How to Run the Demonstration
 ### Import the supplied Bankdemo enterprise server:

--- a/tutorial/gettingstarted/visualstudio/PLIDemo.md
+++ b/tutorial/gettingstarted/visualstudio/PLIDemo.md
@@ -38,10 +38,10 @@ You must start the HACloud session server before attempting to use the HACloud T
 1. Ensure you have a 64-bit Java installed and added to the PATH environment variable.
 2. Open the Windows Service Manager.
 3. Go to **Micro Focus HA Cloud** and click **Start the service**. 
-4. Alternatively, you can start the session by opening a command prompt and executing the following command:
+4. Alternatively, you can start the session by opening a command prompt as administrator and executing the following command:
 
     ```
-    net start hacloud
+    net start mfhacloud
     ```
 
 

--- a/tutorial/gettingstarted/visualstudio/readme.md
+++ b/tutorial/gettingstarted/visualstudio/readme.md
@@ -1,7 +1,9 @@
 # Getting started with Micro Focus Enterprise Developer for Visual Studio 2022
 
 ## Overview
+
 This set of tutorials guides you through the use of Micro Focus Enterprise Developer for Visual Studio 2022. They provide a basic understanding of how the product operates. They'll walk you through:
+
 - [Starting the Visual Studio Integrated Development Environment](#starting-the-visual-studio-integrated-development-environment)
 - [Adding files to your Visual Studio project](#adding-files-to-your-visual-studio-project)
 - [File, Project and IDE properties and settings](#file-project-and-ide-properties-and-settings)
@@ -15,7 +17,6 @@ This set of tutorials guides you through the use of Micro Focus Enterprise Devel
 These tutorials are designed for developers who have experience with developing COBOL on the mainframe but do not necessarily have a working knowledge of the Visual Studio Integrated Development Environment (IDE). The tutorials provide a basic understanding of the features offered in Enterprise Developer for Visual Studio 2022 to develop and maintain both simple COBOL and mainframe subsystem applications.
 
 Other tutorials, which are designed for Administrators, are available.
-
 
 **Download the demonstration application**
 
@@ -47,7 +48,7 @@ A preconfigured, fully executing application, BankDemo, is available from the Mi
 
    If you have an active firewall on the machine that is running your Directory Server and enterprise server instances, and you want remote clients to be able to connect to them, you must ensure that the firewall allows access to the ports that you are using.
     
-   For example, Directory Server is configured, by default, to use port 86. Your must configure your firewall to allow TCP and UDP access to this port. Similarly, the enterprise server instance you create as part of this tutorial, BANKDEMO, has listeners which use ports 9003 and 9023. For remote clients to be able to submit JCL jobs or connect a TN3270 terminal to these listeners, your firewall must permit access to these ports.
+   For example, Directory Server is configured, by default, to use port 86. You must configure your firewall to allow TCP and UDP access to this port. Similarly, the enterprise server instance you create as part of this tutorial, BANKDEMO, has listeners which use ports 9003 and 9023. For remote clients to be able to submit JCL jobs or connect a TN3270 terminal to these listeners, your firewall must permit access to these ports.
 
    We recommend that, if you want remote users to access Enterprise Server functionality through the firewall, you use fixed port values so that you can control access via these.
 

--- a/tutorial/gettingstarted/visualstudio/readme.md
+++ b/tutorial/gettingstarted/visualstudio/readme.md
@@ -819,6 +819,14 @@ In the previous step, Unit Testing the Batch Application, you used the BANKDEMO 
 
 As with JCL, execution of the jobs requires a previously configured Micro Focus enterprise server.
 
+Before you process, ensure that Micro Focus Host Access for the Cloud (HA Cloud) is running:
+
+1. Go the the Start menu and open the Services application.
+
+2. Navigate to the Micro Focus HA Cloud service and check that its status is set to **Running**.
+
+3. If it is not running, right-click and click **Start**.
+
 **Executing the CICS application**
 
 The CICS application requires that you use a 3270 terminal emulator. The installation of Enterprise Developer includes the Micro Focus Rumba+ Desktop emulator. Rumba+ Desktop is available as a standalone application, Rumba+ Desktop, and is also available as a TN3270 Mainframe Display embedded within the IDE.

--- a/tutorial/gettingstarted/visualstudio/readme.md
+++ b/tutorial/gettingstarted/visualstudio/readme.md
@@ -679,13 +679,23 @@ This sample provides a PowerShell script that creates the region definition to u
 
     This executes the script and creates the Enterprise Server region definition file, **BANKDEMO.xml**, in the same folder. The file is configured for the location in which you have saved the sample files.
 
-To import the definition of the Bankdemo logical server (LSER) in Enterprise Server:
+Ensure that the default settings are applied to the Directory Sever:
 
-1.  In Visual Studio, open the Server Explorer window.
+1.  Click the **Start** menu and open the **Services** application. Navigate to Micro Focus Directory Server to view its status and set it to **Running** if it is not already started.
+
+2.  In Visual Studio, open the Server Explorer window.
 
     If the window is not visible, click **View** \> **Server Explorer** (or **View** \> **Other Windows** \> **Server Explorer**).
 
     ![](images/03218b9fa5693aaca14ff3cf3aa3dd1b.jpg) **Tip:** Use the Auto Hide button (![](images/bf74b6a329048075497d723393231eba.jpg)) in the Server Explorer toolbar to pin the window to the IDE window.
+
+3.  Right-click **Micro Focus Servers** and select **Directory Server Configuration**. This opens the Micro Focus Directory Server window. 
+
+4.  Ensure that Host name is localhost and the Port number is 86.
+
+To import the definition of the Bankdemo logical server (LSER) in Enterprise Server:
+
+1.  In Visual Studio, open the Server Explorer window.
 
 2.  Expand **Micro Focus Servers**.
 

--- a/tutorial/gettingstarted/visualstudio/readme.md
+++ b/tutorial/gettingstarted/visualstudio/readme.md
@@ -819,7 +819,7 @@ In the previous step, Unit Testing the Batch Application, you used the BANKDEMO 
 
 As with JCL, execution of the jobs requires a previously configured Micro Focus enterprise server.
 
-Before you proceed, ensure that Micro Focus Host Access for the Cloud (HA Cloud) is running:
+Before you proceed, ensure that Micro Focus Host Access for the Cloud (HACloud) is running:
 
 1. Go the the Start menu and open the Services application.
 

--- a/tutorial/gettingstarted/visualstudio/readme.md
+++ b/tutorial/gettingstarted/visualstudio/readme.md
@@ -819,7 +819,7 @@ In the previous step, Unit Testing the Batch Application, you used the BANKDEMO 
 
 As with JCL, execution of the jobs requires a previously configured Micro Focus enterprise server.
 
-Before you process, ensure that Micro Focus Host Access for the Cloud (HA Cloud) is running:
+Before you proceed, ensure that Micro Focus Host Access for the Cloud (HA Cloud) is running:
 
 1. Go the the Start menu and open the Services application.
 


### PR DESCRIPTION
These are general changes to the tutorials to improve usability by including more steps to verify the MFDS and HACloud and how to show the local ESCWA in Server Explorer. 

Defects: 665093, 665160, 667160

- Add local ESCWA to Server Explorer in Eclipse
- Start HACloud session server in PL/I demos
- Check MFDS
- Typos